### PR TITLE
Allow user to define custom schema field types

### DIFF
--- a/config/schema.xml.erb
+++ b/config/schema.xml.erb
@@ -48,7 +48,7 @@
   <fieldType name="float" class="solr.TrieFloatField" precisionStep="0" positionIncrementGap="0"/>
   <fieldType name="long" class="solr.TrieLongField" precisionStep="0" positionIncrementGap="0"/>
   <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0" positionIncrementGap="0"/>
-   
+  <%= @custom_fields %>
  </types>
  <fields>
     <field name="id"  type="string" indexed="true"  stored="true"/>

--- a/lib/datastax_rails/tasks/column_family.rb
+++ b/lib/datastax_rails/tasks/column_family.rb
@@ -41,6 +41,7 @@ module DatastaxRails
         @fields = []
         @copy_fields = []
         @fulltext_fields = []
+        @custom_fields = ""
         model.attribute_definitions.values.each do |attr|
           coder = attr.coder
           if coder.options[:solr_type]
@@ -68,6 +69,9 @@ module DatastaxRails
         @copy_fields.sort! {|a,b| a[:source] <=> b[:source]}
         @fulltext_fields.sort!
         
+        user_schema = File.join(Rails.root, "config", "solr", "schema.xml")
+        @custom_fields = File.read(user_schema) if File.exists?(user_schema)
+          
         return ERB.new(File.read(File.join(File.dirname(__FILE__),"..","..","..","config","schema.xml.erb"))).result(binding)
       end
       


### PR DESCRIPTION
This is a small fix that allows users to write custom `fieldType` elements which will get included in the generated schema that is uploaded to Solr. 

I think this is going to be a temporary solution because it only allows users to append `fieldType` elements to the `types` container. I foresee a need in the future where configuring the schema needs to be more flexible to allow users to add types, fields and customize other aspects of the schema. 

But for now, this gets us moving...
