### PR TITLE
Released 1.1.0.7 gem

### DIFF
--- a/lib/datastax_rails/version.rb
+++ b/lib/datastax_rails/version.rb
@@ -1,4 +1,4 @@
 module DatastaxRails
   # The current version of the gem
-  VERSION = "1.1.0.7"
+  VERSION = "1.1.1-alpha"
 end


### PR DESCRIPTION
Updated the version file to build the 1.1.0.7 gem which allows support for making custom field types. 

Subsequently updated the version file again to reflect an alpha version so multiple checkouts of the code wouldn't yield the same version number. 
