### PR TITLE
Add highlighting to full text search

### DIFF
--- a/lib/datastax_rails/collection.rb
+++ b/lib/datastax_rails/collection.rb
@@ -8,7 +8,7 @@ module DatastaxRails
     #   @return [Fixnum] the per page value of the search that produced these results (used by will_paginate)
     # @!attribute [r] current_page
     #   @return [Fixnum] the current page of the search that produced these results (used by will_paginate)
-    attr_accessor :last_column_name, :total_entries, :per_page, :current_page
+    attr_accessor :last_column_name, :total_entries, :per_page, :current_page, :highlights
     
     def inspect
       "<DatastaxRails::Collection##{object_id} contents: #{super} last_column_name: #{last_column_name.inspect}>"

--- a/spec/datastax_rails/relation/search_methods_spec.rb
+++ b/spec/datastax_rails/relation/search_methods_spec.rb
@@ -186,4 +186,18 @@ describe DatastaxRails::Relation do
       @relation.fulltext("swimming").should_not be_empty
     end
   end
+  
+  describe '#highlight' do
+    let(:hl) { @relation.highlight(:name, :description, :snippet => 3, :fragsize => 200) }
+    
+    it { expect(hl.highlight_options[:fields]).to eq [:name, :description] }
+    it { expect(hl.highlight_options[:snippet]).to eq 3 }
+    it { expect(hl.highlight_options[:fragsize]).to eq 200 }
+    
+    context 'with duplicate fields' do
+      let(:hl) { @relation.highlight(:name, :description, :name) }
+      
+      it { expect(hl.highlight_options[:fields]).to eq [:name, :description] }
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,17 @@ Dir[File.expand_path(File.join(ENGINE_RAILS_ROOT, "spec/support/**/*.rb"))].each
 
 RSpec.configure do |config|
   config.alias_it_should_behave_like_to :it_has_behavior, 'has behavior:'
+  
+  # Use a focus tag to filter specific specs. This helps if you need to
+  # focus on one spec instead of the whole suite.
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
+  
+  # Filter slow specs. Add a :slow tag to the spec to keep it from
+  # running unless the SLOW_SPECS environment variable is set.
+  config.treat_symbols_as_metadata_keys_with_true_values = true
+  config.filter_run_excluding :slow unless ENV['SLOW_SPECS']
+  
   config.before(:each) do
     DatastaxRails::Base.recorded_classes = {}
   end


### PR DESCRIPTION
Allows users to chain `#highlight(...)` to a `Datastax::Relation` to enable Solr highlighting when performing full text searching.

Highlight results can be found on the `Datastax::Collection#highlights` method after a Solr search respose is returned.
