### PR TITLE
Encode/decode time from utc to the local zone

### DIFF
--- a/lib/datastax_rails/relation/search_methods.rb
+++ b/lib/datastax_rails/relation/search_methods.rb
@@ -485,8 +485,12 @@ module DatastaxRails
     def solr_format(value)
       return value unless use_solr_value
       case
-        when value.is_a?(Date), value.is_a?(Time)
-          value.strftime('%Y-%m-%dT%H:%M:%SZ')
+        when value.is_a?(Time)
+          value.utc.strftime(DatastaxRails::Types::TimeType::FORMAT)
+        when value.is_a?(DateTime)
+          value.to_time.utc.strftime(DatastaxRails::Types::TimeType::FORMAT)
+        when value.is_a?(Date)
+          value.strftime(DatastaxRails::Types::TimeType::FORMAT)
         when value.is_a?(Array)
           value.collect {|v| v.gsub(/ /,"\\ ") }.join(" OR ")
         when value.is_a?(Fixnum)

--- a/lib/datastax_rails/types/time_type.rb
+++ b/lib/datastax_rails/types/time_type.rb
@@ -7,12 +7,12 @@ module DatastaxRails
       def encode(time)
         return unless time
         raise ArgumentError.new("#{self} requires a Time") unless time.kind_of?(Time)
-        time.strftime(FORMAT)
+        time.utc.strftime(FORMAT)
       end
 
       def decode(str)
         return str if str.kind_of?(Time)
-        Time.parse(str) rescue nil
+        Time.zone.parse(str) rescue nil
       end
       
       def full_solr_range

--- a/spec/datastax_rails/relation/search_methods_spec.rb
+++ b/spec/datastax_rails/relation/search_methods_spec.rb
@@ -200,4 +200,24 @@ describe DatastaxRails::Relation do
       it { expect(hl.highlight_options[:fields]).to eq [:name, :description] }
     end
   end
+  
+  describe '#solr_format' do
+    context 'when formatting Time' do
+      let(:time) { Time.new 2011, 10, 9, 8, 7, 6, "-05:00" }
+      
+      it { expect(@relation.solr_format(time)).to eq '2011-10-09T13:07:06Z' }
+    end
+    
+    context 'when formatting Date' do
+      let(:date) { Date.new 2001, 2, 3 }
+      
+      it { expect(@relation.solr_format(date)).to eq '2001-02-03T00:00:00Z' }
+    end
+    
+    context 'when formatting DateTime' do
+      let(:datetime) { DateTime.new 2001, 2, 3, 4, 5, 6, "-07:00" }
+      
+      it { expect(@relation.solr_format(datetime)).to eq '2001-02-03T11:05:06Z' }
+    end
+  end
 end

--- a/spec/datastax_rails/types/time_type_spec.rb
+++ b/spec/datastax_rails/types/time_type_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe DatastaxRails::Types::TimeType do
+  let(:coder) { DatastaxRails::Types::TimeType.new }
+  let(:utc_time) { Time.utc(2013, 12, 11, 10, 9, 8) }
+  
+  describe "#encode" do
+    let(:local_time) { Time.new(2011, 10, 9, 8, 7, 6, "-05:00") }
+    
+    it { expect(coder.encode(nil)).to be_nil }
+    it { expect{coder.encode("bad time")}.to raise_error(ArgumentError) }
+    it { expect(coder.encode(utc_time)).to eq "2013-12-11T10:09:08Z" }
+    it { expect(coder.encode(local_time)).to eq "2011-10-09T13:07:06Z" }
+  end
+  
+  describe "#decode" do
+    let(:time) { "2013-12-11T10:09:08Z" }
+    
+    it { expect(coder.decode(time)).to eq utc_time }
+    it { expect(coder.decode(utc_time)).to eq utc_time }
+    
+    context "when timezone is not UTC" do
+      before(:each) { Time.zone = "Eastern Time (US & Canada)" }
+      
+      it { expect(coder.decode(time)).to eq Time.new(2013, 12, 11, 5, 9, 8, '-05:00') }
+    end
+  end
+end


### PR DESCRIPTION
Ensures time is always persisted and queried as UTC (just like ActiveRecord) but also properly converts the model's datetime fields back to the local timezone if set.
