### PR TITLE
Added the ability to set facet.threads on a given query

### DIFF
--- a/lib/datastax_rails/relation.rb
+++ b/lib/datastax_rails/relation.rb
@@ -7,7 +7,7 @@ module DatastaxRails
     MULTI_VALUE_METHODS = %i(order where where_not fulltext greater_than less_than select stats field_facet
                              range_facet slow_order)
     SINGLE_VALUE_METHODS = %i(page per_page reverse_order query_parser consistency ttl use_solr escape group
-                              allow_filtering)
+                              allow_filtering facet_threads)
 
     SOLR_CHAR_RX = /([\+\!\(\)\[\]\^\"\~\:\'\=\/]+)/
 
@@ -256,7 +256,7 @@ module DatastaxRails
         return :solr
       else
         [order_values, where_not_values, fulltext_values, greater_than_values, less_than_values, field_facet_values,
-         range_facet_values, group_value].each do |solr_only_stuff|
+         range_facet_values, group_value, facet_threads_value].each do |solr_only_stuff|
            return :solr unless solr_only_stuff.blank?
          end
         return :solr unless group_value.blank?
@@ -472,6 +472,8 @@ module DatastaxRails
       # Facet Fields
       unless field_facet_values.empty?
         params['facet'] = 'true'
+        params['facet.threads'] = facet_threads_value if facet_threads_value.present?
+
         facet_fields = []
         field_facet_values.each do |facet|
           facet_field = facet[:field]

--- a/lib/datastax_rails/relation/facet_methods.rb
+++ b/lib/datastax_rails/relation/facet_methods.rb
@@ -75,5 +75,16 @@ module DatastaxRails
                                 }
       end
     end
+
+    # New option as of SOLR 4.5
+    # limited to field_facets
+    def facet_threads(thread_count = 0)
+      # thread_count == -1 will create a THREAD per field_facet up to Integer.MAX_VALUE
+      thread_count = -1 if thread_count < 0
+
+      clone.tap do |r|
+        r.facet_threads_value = thread_count
+      end
+    end
   end
 end


### PR DESCRIPTION
Facet.threads is a query level setting that determines the number
of threads computing field_facets in parallel.  The setting is only
applicable to field_facets
